### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration with GitHub",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
## Summary
Add the missing **GitHub Skills** activity to the backend activity list so it appears in the UI and is available for signup.

## Changes
- Added `GitHub Skills` entry to `activities` in `src/app.py`
- Included description, schedule, max participants, and an empty participant list

## Why
This addresses the missing activity reported in issue #6 and makes the activity available for registration like other activities.

Closes #6